### PR TITLE
Allow 'none' encoding for binary data

### DIFF
--- a/lib/Net/SSH/Any.pm
+++ b/lib/Net/SSH/Any.pm
@@ -152,6 +152,7 @@ sub _check_error_after_eval {
 sub _encode_data {
     my $any = shift;
     my $encoding = shift;
+    return 1 if $encoding eq "none";
     if (@_) {
         my $enc = $any->_find_encoding($encoding) or return;
         local $any->{error_prefix} = [@{$any->{error_prefix}}, "data encoding failed"];
@@ -165,6 +166,7 @@ sub _encode_data {
 sub _decode_data {
     my $any = shift;
     my $encoding = shift;
+    return 1 if $encoding eq "none";
     my $enc = $any->_find_encoding($encoding) or return;
     if (@_) {
         local ($@, $SIG{__DIE__});


### PR DESCRIPTION
I was receiving errors when passing binary data to and from the SSH server (utf8 "\xA4" does not map to unicode). This small change allows for passing "none" as an encoding so the binary data won't be a problem.
